### PR TITLE
Table actions in ActionGroup at row start

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "tapp/filament-forum",
-    "version": "2.0.0",
     "description": "Forum and comments package for Filament apps.",
     "type": "library",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "tapp/filament-forum",
+    "version": "2.0.0",
     "description": "Forum and comments package for Filament apps.",
     "type": "library",
     "license": "MIT",

--- a/src/Filament/Resources/Admin/ForumPostResource/Tables/ForumPostsTable.php
+++ b/src/Filament/Resources/Admin/ForumPostResource/Tables/ForumPostsTable.php
@@ -62,7 +62,7 @@ class ForumPostsTable
                     DeleteAction::make(),
                 ])
                     ->tooltip('Actions'),
-            ], position: RecordActionsPosition::AfterColumns)
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),

--- a/src/Filament/Resources/Admin/ForumResource/Tables/ForumsTable.php
+++ b/src/Filament/Resources/Admin/ForumResource/Tables/ForumsTable.php
@@ -92,7 +92,7 @@ class ForumsTable
                     DeleteAction::make(),
                 ])
                     ->tooltip('Actions'),
-            ], position: RecordActionsPosition::AfterColumns)
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),

--- a/src/Filament/Resources/ForumPosts/Tables/ForumPostsTable.php
+++ b/src/Filament/Resources/ForumPosts/Tables/ForumPostsTable.php
@@ -2,9 +2,11 @@
 
 namespace Tapp\FilamentForum\Filament\Resources\ForumPosts\Tables;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\EditAction;
 use Filament\Support\Enums\Alignment;
 use Filament\Tables\Columns\Layout\Stack;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
@@ -37,12 +39,13 @@ class ForumPostsTable
                 //
             ])
             ->recordActions([
-                // Tables\Actions\ViewAction::make(),
-                EditAction::make()
-                    ->icon('heroicon-m-pencil-square')
-                    ->iconButton()
-                    ->visible(fn (ForumPost $record): bool => Auth::check() && $record->user_id === Auth::id()),
-            ])
+                ActionGroup::make([
+                    EditAction::make()
+                        ->icon('heroicon-m-pencil-square')
+                        ->iconButton()
+                        ->visible(fn (ForumPost $record): bool => Auth::check() && $record->user_id === Auth::id()),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 // Tables\Actions\BulkActionGroup::make([
                 //    Tables\Actions\DeleteBulkAction::make(),

--- a/src/Filament/Resources/Forums/ForumResource.php
+++ b/src/Filament/Resources/Forums/ForumResource.php
@@ -9,6 +9,7 @@ use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Section;
 use Filament\Support\Enums\Alignment;
 use Filament\Tables\Columns\Layout\Stack;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Tapp\FilamentForum\Filament\Resources\Forums\Pages\ListForums;
@@ -53,7 +54,7 @@ class ForumResource extends Resource
             ])
             ->recordActions([
                 //
-            ]);
+            ], position: RecordActionsPosition::BeforeColumns);
     }
 
     public static function getInfolistSchema(): array

--- a/src/RelationManagers/ForumUsersRelationManager.php
+++ b/src/RelationManagers/ForumUsersRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentForum\RelationManagers;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\AttachAction;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DetachAction;
@@ -10,6 +11,7 @@ use Filament\Forms;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 
 class ForumUsersRelationManager extends RelationManager
@@ -64,8 +66,10 @@ class ForumUsersRelationManager extends RelationManager
                     ->recordSelectSearchColumns(['name', 'email']),
             ])
             ->recordActions([
-                DetachAction::make(),
-            ])
+                ActionGroup::make([
+                    DetachAction::make(),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DetachBulkAction::make(),


### PR DESCRIPTION
Puts all admin table row actions in a single ActionGroup and positions them at row start (BeforeColumns).

- ForumUsersRelationManager
- Admin ForumsTable / ForumPostsTable
- ForumPosts/Tables/ForumPostsTable
- Forums/ForumResource
- composer.json: add version for path repo installs

Made with [Cursor](https://cursor.com)