### PR TITLE
Add forum and post subscriptions

### DIFF
--- a/database/migrations/create_forum_post_subscriptions_table.php
+++ b/database/migrations/create_forum_post_subscriptions_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('forum_post_subscriptions', function (Blueprint $table) {
+            $table->id();
+            $tenantColumn = null;
+
+            if (config('filament-forum.tenancy.enabled')) {
+                $tenantModel = config('filament-forum.tenancy.model');
+                $tenantColumn = config('filament-forum.tenancy.column')
+                    ?: str($tenantModel)->classBasename()->snake()->append('_id')->toString();
+
+                $table->foreignIdFor($tenantModel)
+                    ->constrained()
+                    ->cascadeOnDelete();
+            }
+
+            $table->foreignId('forum_post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $uniqueColumns = config('filament-forum.tenancy.enabled')
+                ? [(string) $tenantColumn, 'forum_post_id', 'user_id']
+                : ['forum_post_id', 'user_id'];
+
+            $table->unique($uniqueColumns);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('forum_post_subscriptions');
+    }
+};

--- a/database/migrations/create_forum_subscriptions_table.php
+++ b/database/migrations/create_forum_subscriptions_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('forum_subscriptions', function (Blueprint $table) {
+            $table->id();
+            $tenantColumn = null;
+
+            if (config('filament-forum.tenancy.enabled')) {
+                $tenantModel = config('filament-forum.tenancy.model');
+                $tenantColumn = config('filament-forum.tenancy.column')
+                    ?: str($tenantModel)->classBasename()->snake()->append('_id')->toString();
+
+                $table->foreignIdFor($tenantModel)
+                    ->constrained()
+                    ->cascadeOnDelete();
+            }
+
+            $table->foreignId('forum_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $uniqueColumns = config('filament-forum.tenancy.enabled')
+                ? [(string) $tenantColumn, 'forum_id', 'user_id']
+                : ['forum_id', 'user_id'];
+
+            $table->unique($uniqueColumns);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('forum_subscriptions');
+    }
+};

--- a/resources/lang/en/filament-forum.php
+++ b/resources/lang/en/filament-forum.php
@@ -17,6 +17,8 @@ return [
     'forum.delete.modal.heading' => 'Delete Forum',
     'forum.delete.modal.description' => 'Are you sure you want to delete this forum? This action cannot be undone.',
     'forum.delete.notification' => 'Forum deleted successfully',
+    'forum.subscribe' => 'Follow forum',
+    'forum.unsubscribe' => 'Unfollow forum',
 
     /*
     |--------------------------------------------------------------------------
@@ -32,6 +34,8 @@ return [
     'forum-post.unknown' => 'Unknown',
     'forum-post.last-reply' => 'Last reply',
     'forum-post.toggle-favorite' => 'Toggle Favorite',
+    'forum-post.subscribe' => 'Follow post',
+    'forum-post.unsubscribe' => 'Unfollow post',
     'forum-post.views' => '{0} No views yet|{1} :value view|[2,*] :value views',
     'forum-post.replies' => '{0} No reply yet|{1} :value reply|[2,*] :value replies',
 

--- a/src/Events/ForumPostSubscribed.php
+++ b/src/Events/ForumPostSubscribed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tapp\FilamentForum\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Tapp\FilamentForum\Models\ForumPost;
+
+class ForumPostSubscribed
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public mixed $user,
+        public ForumPost $forumPost,
+    ) {}
+}

--- a/src/Events/ForumPostUnsubscribed.php
+++ b/src/Events/ForumPostUnsubscribed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tapp\FilamentForum\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Tapp\FilamentForum\Models\ForumPost;
+
+class ForumPostUnsubscribed
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public mixed $user,
+        public ForumPost $forumPost,
+    ) {}
+}

--- a/src/Events/ForumSubscribed.php
+++ b/src/Events/ForumSubscribed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tapp\FilamentForum\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Tapp\FilamentForum\Models\Forum;
+
+class ForumSubscribed
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public mixed $user,
+        public Forum $forum,
+    ) {}
+}

--- a/src/Events/ForumUnsubscribed.php
+++ b/src/Events/ForumUnsubscribed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tapp\FilamentForum\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Tapp\FilamentForum\Models\Forum;
+
+class ForumUnsubscribed
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public mixed $user,
+        public Forum $forum,
+    ) {}
+}

--- a/src/Filament/Resources/ForumPosts/Schemas/ForumPostInfolist.php
+++ b/src/Filament/Resources/ForumPosts/Schemas/ForumPostInfolist.php
@@ -28,6 +28,13 @@ class ForumPostInfolist
                             ->tooltip(__('filament-forum::filament-forum.forum-post.toggle-favorite'))
                             ->icon(fn (ForumPost $record) => $record->isFavorite() ? 'heroicon-s-star' : 'heroicon-o-star')
                             ->action(fn (ForumPost $record) => $record->toggleFavorite()),
+                        Action::make('subscription')
+                            ->iconButton()
+                            ->tooltip(fn (ForumPost $record) => $record->isSubscribed()
+                                ? __('filament-forum::filament-forum.forum-post.unsubscribe')
+                                : __('filament-forum::filament-forum.forum-post.subscribe'))
+                            ->icon(fn (ForumPost $record) => $record->isSubscribed() ? 'heroicon-s-bell' : 'heroicon-o-bell')
+                            ->action(fn (ForumPost $record) => $record->toggleSubscription()),
                         Action::make('share')
                             ->icon('heroicon-o-share')
                             ->action(function ($livewire) {

--- a/src/Filament/Resources/Forums/Pages/ManageForumPosts.php
+++ b/src/Filament/Resources/Forums/Pages/ManageForumPosts.php
@@ -3,14 +3,17 @@
 namespace Tapp\FilamentForum\Filament\Resources\Forums\Pages;
 
 use BackedEnum;
+use Filament\Actions\Action;
 use Filament\Actions\CreateAction;
 use Filament\Panel;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Facades\Auth;
 use Tapp\FilamentForum\Filament\Resources\ForumPosts\ForumPostResource;
 use Tapp\FilamentForum\Filament\Resources\ForumPosts\Tables\ForumPostsTable;
 use Tapp\FilamentForum\Filament\Resources\Forums\ForumResource;
+use Tapp\FilamentForum\Models\Forum;
 use Tapp\FilamentForum\Models\ForumPost;
 
 class ManageForumPosts extends ManageRelatedRecords
@@ -43,8 +46,20 @@ class ManageForumPosts extends ManageRelatedRecords
     {
         return ForumPostsTable::configure($table)
             ->headerActions([
+                Action::make('subscription')
+                    ->label(fn (): string => $this->forumSubscriptionRecord()->isSubscribed()
+                        ? __('filament-forum::filament-forum.forum.unsubscribe')
+                        : __('filament-forum::filament-forum.forum.subscribe'))
+                    ->icon(fn (): string => $this->forumSubscriptionRecord()->isSubscribed() ? 'heroicon-s-bell' : 'heroicon-o-bell')
+                    ->visible(fn (): bool => Auth::check())
+                    ->action(fn () => $this->toggleForumSubscription()),
                 CreateAction::make(),
             ]);
+    }
+
+    public function toggleForumSubscription(): void
+    {
+        $this->forumSubscriptionRecord()->toggleSubscription();
     }
 
     public function toggleFavorite($recordId)
@@ -53,5 +68,13 @@ class ManageForumPosts extends ManageRelatedRecords
         $forumPostrecord->toggleFavorite();
 
         $this->dispatch('favorite-toggled', recordId: $recordId, isFavorite: $forumPostrecord->isFavorite());
+    }
+
+    protected function forumSubscriptionRecord(): Forum
+    {
+        /** @var Forum $forum */
+        $forum = $this->getOwnerRecord();
+
+        return $forum;
     }
 }

--- a/src/FilamentForumServiceProvider.php
+++ b/src/FilamentForumServiceProvider.php
@@ -34,6 +34,8 @@ class FilamentForumServiceProvider extends PackageServiceProvider
                 'create_forum_user_table',
                 'create_forum_posts_table',
                 'create_favorite_forum_post_table',
+                'create_forum_subscriptions_table',
+                'create_forum_post_subscriptions_table',
                 'create_forum_post_views_table',
                 'create_forum_comments_table',
                 'create_forum_comment_reactions_table',

--- a/src/Models/Forum.php
+++ b/src/Models/Forum.php
@@ -16,10 +16,12 @@ use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Tapp\FilamentForum\Database\Factories\ForumFactory;
 use Tapp\FilamentForum\Models\Traits\BelongsToTenant;
+use Tapp\FilamentForum\Models\Traits\CanSubscribeToForum;
 
 class Forum extends Model implements HasMedia
 {
     use BelongsToTenant;
+    use CanSubscribeToForum;
 
     /** @use HasFactory<ForumFactory> */
     use HasFactory;

--- a/src/Models/ForumPost.php
+++ b/src/Models/ForumPost.php
@@ -13,11 +13,13 @@ use Tapp\FilamentForum\Events\ForumPostCreated;
 use Tapp\FilamentForum\Events\PostWasReacted;
 use Tapp\FilamentForum\Models\Traits\BelongsToTenant;
 use Tapp\FilamentForum\Models\Traits\CanFavoriteForumPost;
+use Tapp\FilamentForum\Models\Traits\CanSubscribeToForumPost;
 
 class ForumPost extends Model
 {
     use BelongsToTenant;
     use CanFavoriteForumPost;
+    use CanSubscribeToForumPost;
 
     /** @use HasFactory<ForumPostFactory> */
     use HasFactory;

--- a/src/Models/Traits/CanSubscribeToForum.php
+++ b/src/Models/Traits/CanSubscribeToForum.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tapp\FilamentForum\Models\Traits;
+
+use Filament\Facades\Filament;
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Tapp\FilamentForum\Events\ForumSubscribed;
+use Tapp\FilamentForum\Events\ForumUnsubscribed;
+
+trait CanSubscribeToForum
+{
+    public function toggleSubscription($user = null): void
+    {
+        $user ??= auth()->user();
+
+        if (! $user) {
+            return;
+        }
+
+        if ($this->isSubscribed($user)) {
+            $this->subscribedUsers()->detach($user->getKey());
+
+            ForumUnsubscribed::dispatch($user, $this);
+
+            return;
+        }
+
+        $this->subscribedUsers()->attach($user->getKey(), $this->subscriptionPivotData());
+
+        ForumSubscribed::dispatch($user, $this);
+    }
+
+    public function isSubscribed($user = null): bool
+    {
+        $user ??= auth()->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        return $this->subscribedUsers()
+            ->whereKey($user->getKey())
+            ->when(
+                config('filament-forum.tenancy.enabled') && Filament::hasTenancy(),
+                fn (Builder $query) => $query->where(
+                    'forum_subscriptions.'.static::getTenantColumnName(),
+                    Filament::getTenant()->getKey(),
+                ),
+            )
+            ->exists();
+    }
+
+    public function getIsSubscribedAttribute(): bool
+    {
+        return $this->isSubscribed();
+    }
+
+    public function subscribedUsers(): BelongsToMany
+    {
+        $relationship = $this->belongsToMany(config('auth.providers.users.model'), 'forum_subscriptions');
+
+        if (config('filament-forum.tenancy.enabled')) {
+            $relationship->withPivot(static::getTenantColumnName());
+        }
+
+        return $relationship->withTimestamps();
+    }
+
+    public function scopeSubscribed($query): Builder
+    {
+        return $query->whereHas('subscribedUsers', function ($query) {
+            $query->where('forum_subscriptions.user_id', auth()->id());
+
+            if (config('filament-forum.tenancy.enabled') && Filament::hasTenancy()) {
+                $query->where('forum_subscriptions.'.static::getTenantColumnName(), Filament::getTenant()->getKey());
+            }
+        });
+    }
+
+    public function scopeNotSubscribed($query): Builder
+    {
+        return $query->whereDoesntHave('subscribedUsers', function ($query) {
+            $query->where('forum_subscriptions.user_id', auth()->id());
+
+            if (config('filament-forum.tenancy.enabled') && Filament::hasTenancy()) {
+                $query->where('forum_subscriptions.'.static::getTenantColumnName(), Filament::getTenant()->getKey());
+            }
+        });
+    }
+
+    protected function subscriptionPivotData(): array
+    {
+        if (! config('filament-forum.tenancy.enabled') || ! Filament::hasTenancy()) {
+            return [];
+        }
+
+        return [
+            static::getTenantColumnName() => Filament::getTenant()->getKey(),
+        ];
+    }
+}

--- a/src/Models/Traits/CanSubscribeToForumPost.php
+++ b/src/Models/Traits/CanSubscribeToForumPost.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tapp\FilamentForum\Models\Traits;
+
+use Filament\Facades\Filament;
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Tapp\FilamentForum\Events\ForumPostSubscribed;
+use Tapp\FilamentForum\Events\ForumPostUnsubscribed;
+
+trait CanSubscribeToForumPost
+{
+    public function toggleSubscription($user = null): void
+    {
+        $user ??= auth()->user();
+
+        if (! $user) {
+            return;
+        }
+
+        if ($this->isSubscribed($user)) {
+            $this->subscribedUsers()->detach($user->getKey());
+
+            ForumPostUnsubscribed::dispatch($user, $this);
+
+            return;
+        }
+
+        $this->subscribedUsers()->attach($user->getKey(), $this->subscriptionPivotData());
+
+        ForumPostSubscribed::dispatch($user, $this);
+    }
+
+    public function isSubscribed($user = null): bool
+    {
+        $user ??= auth()->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        return $this->subscribedUsers()
+            ->whereKey($user->getKey())
+            ->when(
+                config('filament-forum.tenancy.enabled') && Filament::hasTenancy(),
+                fn (Builder $query) => $query->where(
+                    'forum_post_subscriptions.'.static::getTenantColumnName(),
+                    Filament::getTenant()->getKey(),
+                ),
+            )
+            ->exists();
+    }
+
+    public function getIsSubscribedAttribute(): bool
+    {
+        return $this->isSubscribed();
+    }
+
+    public function subscribedUsers(): BelongsToMany
+    {
+        $relationship = $this->belongsToMany(config('auth.providers.users.model'), 'forum_post_subscriptions');
+
+        if (config('filament-forum.tenancy.enabled')) {
+            $relationship->withPivot(static::getTenantColumnName());
+        }
+
+        return $relationship->withTimestamps();
+    }
+
+    public function scopeSubscribed($query): Builder
+    {
+        return $query->whereHas('subscribedUsers', function ($query) {
+            $query->where('forum_post_subscriptions.user_id', auth()->id());
+
+            if (config('filament-forum.tenancy.enabled') && Filament::hasTenancy()) {
+                $query->where('forum_post_subscriptions.'.static::getTenantColumnName(), Filament::getTenant()->getKey());
+            }
+        });
+    }
+
+    public function scopeNotSubscribed($query): Builder
+    {
+        return $query->whereDoesntHave('subscribedUsers', function ($query) {
+            $query->where('forum_post_subscriptions.user_id', auth()->id());
+
+            if (config('filament-forum.tenancy.enabled') && Filament::hasTenancy()) {
+                $query->where('forum_post_subscriptions.'.static::getTenantColumnName(), Filament::getTenant()->getKey());
+            }
+        });
+    }
+
+    protected function subscriptionPivotData(): array
+    {
+        if (! config('filament-forum.tenancy.enabled') || ! Filament::hasTenancy()) {
+            return [];
+        }
+
+        return [
+            static::getTenantColumnName() => Filament::getTenant()->getKey(),
+        ];
+    }
+}

--- a/src/Models/Traits/HasForumSubscriptions.php
+++ b/src/Models/Traits/HasForumSubscriptions.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tapp\FilamentForum\Models\Traits;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Tapp\FilamentForum\Models\Forum;
+use Tapp\FilamentForum\Models\ForumPost;
+
+trait HasForumSubscriptions
+{
+    public function subscribedForums(): BelongsToMany
+    {
+        $relationship = $this->belongsToMany(Forum::class, 'forum_subscriptions');
+
+        if (config('filament-forum.tenancy.enabled')) {
+            $relationship->withPivot(Forum::getTenantColumnName());
+        }
+
+        return $relationship->withTimestamps();
+    }
+
+    public function subscribedForumPosts(): BelongsToMany
+    {
+        $relationship = $this->belongsToMany(ForumPost::class, 'forum_post_subscriptions');
+
+        if (config('filament-forum.tenancy.enabled')) {
+            $relationship->withPivot(ForumPost::getTenantColumnName());
+        }
+
+        return $relationship->withTimestamps();
+    }
+}

--- a/tests/Feature/ForumSubscriptionTest.php
+++ b/tests/Feature/ForumSubscriptionTest.php
@@ -1,0 +1,152 @@
+<?php
+
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Event;
+use Tapp\FilamentForum\Events\ForumPostSubscribed;
+use Tapp\FilamentForum\Events\ForumPostUnsubscribed;
+use Tapp\FilamentForum\Events\ForumSubscribed;
+use Tapp\FilamentForum\Events\ForumUnsubscribed;
+use Tapp\FilamentForum\Models\Forum;
+use Tapp\FilamentForum\Models\ForumPost;
+
+beforeEach(function () {
+    $this->userModel = config('filament-forum.user.model');
+    $this->tenantModel = config('filament-forum.tenancy.model');
+});
+
+it('can toggle forum subscriptions with tenancy enabled', function () {
+    Event::fake();
+
+    $tenantModel = $this->tenantModel;
+    $userModel = $this->userModel;
+
+    $team = $tenantModel::factory()->create();
+    $user = $userModel::factory()->create();
+
+    actingAs($user);
+    Filament::setTenant($team);
+
+    $tenantColumn = Forum::getTenantColumnName();
+
+    $forum = Forum::factory()->create([
+        $tenantColumn => $team->id,
+    ]);
+
+    $forum->toggleSubscription();
+
+    $user = $user->fresh();
+    actingAs($user);
+
+    expect($user->subscribedForums()->count())->toBe(1);
+    expect($user->subscribedForums->first()->id)->toBe($forum->id);
+    expect($forum->isSubscribed())->toBeTrue();
+    expect($user->subscribedForums()->first()->pivot->{$tenantColumn})->toBe($team->id);
+
+    Event::assertDispatched(ForumSubscribed::class, fn (ForumSubscribed $event): bool => $event->forum->is($forum) && $event->user->is($user));
+
+    $forum->toggleSubscription();
+
+    $user = $user->fresh();
+    actingAs($user);
+
+    expect($user->subscribedForums()->count())->toBe(0);
+    expect($forum->isSubscribed())->toBeFalse();
+
+    Event::assertDispatched(ForumUnsubscribed::class, fn (ForumUnsubscribed $event): bool => $event->forum->is($forum) && $event->user->is($user));
+});
+
+it('can toggle forum post subscriptions with tenancy enabled', function () {
+    Event::fake();
+
+    $tenantModel = $this->tenantModel;
+    $userModel = $this->userModel;
+
+    $team = $tenantModel::factory()->create();
+    $user = $userModel::factory()->create();
+
+    actingAs($user);
+    Filament::setTenant($team);
+
+    $tenantColumn = Forum::getTenantColumnName();
+
+    $forum = Forum::factory()->create([
+        $tenantColumn => $team->id,
+    ]);
+
+    $post = ForumPost::factory()->create([
+        'forum_id' => $forum->id,
+        'user_id' => $user->id,
+        $tenantColumn => $team->id,
+    ]);
+
+    $post->toggleSubscription();
+
+    $user = $user->fresh();
+    actingAs($user);
+
+    expect($user->subscribedForumPosts()->count())->toBe(1);
+    expect($user->subscribedForumPosts->first()->id)->toBe($post->id);
+    expect($post->isSubscribed())->toBeTrue();
+    expect($user->subscribedForumPosts()->first()->pivot->{$tenantColumn})->toBe($team->id);
+
+    Event::assertDispatched(ForumPostSubscribed::class, fn (ForumPostSubscribed $event): bool => $event->forumPost->is($post) && $event->user->is($user));
+
+    $post->toggleSubscription();
+
+    $user = $user->fresh();
+    actingAs($user);
+
+    expect($user->subscribedForumPosts()->count())->toBe(0);
+    expect($post->isSubscribed())->toBeFalse();
+
+    Event::assertDispatched(ForumPostUnsubscribed::class, fn (ForumPostUnsubscribed $event): bool => $event->forumPost->is($post) && $event->user->is($user));
+});
+
+it('scopes forum and post subscriptions to the current tenant', function () {
+    $tenantModel = $this->tenantModel;
+    $userModel = $this->userModel;
+
+    $team1 = $tenantModel::factory()->create();
+    $team2 = $tenantModel::factory()->create();
+    $user = $userModel::factory()->create();
+
+    actingAs($user);
+
+    $tenantColumn = Forum::getTenantColumnName();
+
+    $forum1 = Forum::factory()->create([$tenantColumn => $team1->id]);
+    $forum2 = Forum::factory()->create([$tenantColumn => $team2->id]);
+
+    $post1 = ForumPost::factory()->create([
+        'forum_id' => $forum1->id,
+        'user_id' => $user->id,
+        $tenantColumn => $team1->id,
+    ]);
+
+    $post2 = ForumPost::factory()->create([
+        'forum_id' => $forum2->id,
+        'user_id' => $user->id,
+        $tenantColumn => $team2->id,
+    ]);
+
+    Filament::setTenant($team1);
+    $forum1->toggleSubscription();
+    $post1->toggleSubscription();
+
+    Filament::setTenant($team2);
+    $forum2->toggleSubscription();
+    $post2->toggleSubscription();
+
+    expect($user->fresh()->subscribedForums()->count())->toBe(2);
+    expect($user->fresh()->subscribedForumPosts()->count())->toBe(2);
+
+    Filament::setTenant($team1);
+
+    expect(Forum::subscribed()->sole()->id)->toBe($forum1->id);
+    expect(ForumPost::subscribed()->sole()->id)->toBe($post1->id);
+
+    Filament::setTenant($team2);
+
+    expect(Forum::subscribed()->sole()->id)->toBe($forum2->id);
+    expect(ForumPost::subscribed()->sole()->id)->toBe($post2->id);
+});

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -5,12 +5,14 @@ namespace Tapp\FilamentForum\Tests\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Tapp\FilamentForum\Models\Traits\HasFavoriteForumPost;
+use Tapp\FilamentForum\Models\Traits\HasForumSubscriptions;
 use Tapp\FilamentForum\Tests\Database\Factories\UserFactory;
 
 class User extends Authenticatable
 {
     use HasFactory;
     use HasFavoriteForumPost;
+    use HasForumSubscriptions;
 
     protected $guarded = [];
 


### PR DESCRIPTION
## Summary
- add tenant-aware forum and forum post subscription migrations
- add reusable model/user subscription traits plus subscribe/unsubscribe events
- add Filament follow/unfollow actions for forums and posts
- cover forum/post subscriptions, reverse relationships, events, and tenant-scoped queries

## Tests
- composer test
- composer analyse
- composer format