### PR TITLE
Add forum content reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `Filament Forum` will be documented in this file.
 
+## Unreleased
+
+Add reusable forum content reports and moderation review workflow.
+
 ## v2.1.3 - 2026-04-09
 
 Flatten post view: collapsible comment form, no card nesting

--- a/config/filament-forum.php
+++ b/config/filament-forum.php
@@ -1,5 +1,6 @@
 <?php
 
+use Tapp\FilamentForum\Filament\Resources\Admin\ForumContentReportResource;
 use Tapp\FilamentForum\Filament\Resources\ForumPosts\ForumPostResource;
 use Tapp\FilamentForum\Filament\Resources\Forums\ForumResource;
 
@@ -13,6 +14,7 @@ return [
     'admin-resources' => [
         'adminForumResource' => Tapp\FilamentForum\Filament\Resources\Admin\ForumResource::class,
         'adminForumPostResource' => Tapp\FilamentForum\Filament\Resources\Admin\ForumPostResource::class,
+        'adminForumContentReportResource' => ForumContentReportResource::class,
     ],
 
     'user' => [
@@ -57,6 +59,16 @@ return [
             '😮' => 'Wow',
             '😢' => 'Sad',
             '😡' => 'Angry',
+        ],
+    ],
+
+    'reports' => [
+        'reasons' => [
+            'spam' => 'Spam',
+            'harassment' => 'Harassment',
+            'inappropriate' => 'Inappropriate content',
+            'misinformation' => 'Misinformation',
+            'other' => 'Other',
         ],
     ],
 

--- a/database/migrations/create_forum_content_reports_table.php
+++ b/database/migrations/create_forum_content_reports_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('forum_content_reports', function (Blueprint $table) {
+            $table->id();
+
+            if (config('filament-forum.tenancy.enabled')) {
+                $tenantModel = config('filament-forum.tenancy.model');
+                $table->foreignIdFor($tenantModel)
+                    ->constrained()
+                    ->cascadeOnDelete();
+            }
+
+            $table->morphs('reportable');
+            $table->morphs('reporter');
+            $table->string('reason')->nullable();
+            $table->text('details')->nullable();
+            $table->string('status')->default('pending')->index();
+            $userModel = config('auth.providers.users.model');
+            $table->foreignId('reviewed_by_id')->nullable()->constrained((new $userModel)->getTable())->nullOnDelete();
+            $table->timestamp('reviewed_at')->nullable();
+            $table->text('resolution_note')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('forum_content_reports');
+    }
+};

--- a/resources/lang/en/filament-forum.php
+++ b/resources/lang/en/filament-forum.php
@@ -115,6 +115,42 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Reports
+    |--------------------------------------------------------------------------
+    */
+
+    'reports.navigation-label' => 'Content Reports',
+    'reports.label' => 'Content Report',
+    'reports.plural-label' => 'Content Reports',
+    'reports.report' => 'Report',
+    'reports.actions' => 'Report actions',
+    'reports.resolve' => 'Resolve',
+    'reports.dismiss' => 'Dismiss',
+    'reports.reason' => 'Reason',
+    'reports.details' => 'Details',
+    'reports.status' => 'Status',
+    'reports.content' => 'Reported content',
+    'reports.review' => 'Review',
+    'reports.reviewer' => 'Reviewer',
+    'reports.resolution-note' => 'Resolution note',
+    'reports.no-details' => 'No details provided',
+    'reports.no-resolution-note' => 'No resolution note',
+    'reports.not-reviewed' => 'Not reviewed yet',
+    'reports.login-required' => 'You must be logged in to report content',
+    'reports.already-reported' => 'You already reported this content',
+    'reports.submitted' => 'Report submitted',
+    'reports.modal.heading' => 'Report content',
+    'reports.modal.description' => 'Send this to moderators for review.',
+    'reports.modal.submit' => 'Submit report',
+    'reports.status.pending' => 'Pending',
+    'reports.status.resolved' => 'Resolved',
+    'reports.status.dismissed' => 'Dismissed',
+    'reports.table.content-type' => 'Content type',
+    'reports.table.reporter' => 'Reporter',
+    'reports.table.reported-at' => 'Reported',
+
+    /*
+    |--------------------------------------------------------------------------
     | Reactions
     |--------------------------------------------------------------------------
     */

--- a/resources/views/livewire/forum-comments.blade.php
+++ b/resources/views/livewire/forum-comments.blade.php
@@ -113,10 +113,14 @@
                                 @endif
                             </div>
                             
-                            {{-- Edit/Delete Actions --}}
+                            {{-- Report/Edit/Delete Actions --}}
                             @auth
-                                @if($comment->isAuthor(Auth::user()))
-                                    <div class="flex items-center space-x-1">
+                                <div class="flex items-center space-x-1">
+                                    @unless($comment->isAuthor(Auth::user()))
+                                        {{ ($this->reportCommentAction)(['commentId' => $comment->id]) }}
+                                    @endunless
+
+                                    @if($comment->isAuthor(Auth::user()))
                                         @if($editingCommentId !== $comment->id)
                                             <button
                                                 wire:click="editComment({{ $comment->id }})"
@@ -128,8 +132,8 @@
                                             
                                             {{ ($this->deleteCommentAction)(['commentId' => $comment->id]) }}
                                         @endif
-                                    </div>
-                                @endif
+                                    @endif
+                                </div>
                             @endauth
                         </div>
                     </div>

--- a/src/Events/ForumContentReportDismissed.php
+++ b/src/Events/ForumContentReportDismissed.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tapp\FilamentForum\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Tapp\FilamentForum\Models\ForumContentReport;
+
+class ForumContentReportDismissed
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public ForumContentReport $report,
+    ) {}
+}

--- a/src/Events/ForumContentReportResolved.php
+++ b/src/Events/ForumContentReportResolved.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tapp\FilamentForum\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Tapp\FilamentForum\Models\ForumContentReport;
+
+class ForumContentReportResolved
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public ForumContentReport $report,
+    ) {}
+}

--- a/src/Events/ForumContentReported.php
+++ b/src/Events/ForumContentReported.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tapp\FilamentForum\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Tapp\FilamentForum\Models\ForumContentReport;
+
+class ForumContentReported
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public ForumContentReport $report,
+    ) {}
+}

--- a/src/Filament/Actions/ReportForumContentAction.php
+++ b/src/Filament/Actions/ReportForumContentAction.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tapp\FilamentForum\Filament\Actions;
+
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\Auth;
+
+class ReportForumContentAction
+{
+    public static function make(string $name = 'report'): Action
+    {
+        return Action::make($name)
+            ->label(__('filament-forum::filament-forum.reports.report'))
+            ->icon('heroicon-o-flag')
+            ->iconButton()
+            ->color('gray')
+            ->tooltip(__('filament-forum::filament-forum.reports.report'))
+            ->modalHeading(__('filament-forum::filament-forum.reports.modal.heading'))
+            ->modalDescription(__('filament-forum::filament-forum.reports.modal.description'))
+            ->modalSubmitActionLabel(__('filament-forum::filament-forum.reports.modal.submit'))
+            ->schema([
+                Select::make('reason')
+                    ->label(__('filament-forum::filament-forum.reports.reason'))
+                    ->options(config('filament-forum.reports.reasons', []))
+                    ->native(false)
+                    ->required(),
+                Textarea::make('details')
+                    ->label(__('filament-forum::filament-forum.reports.details'))
+                    ->rows(4)
+                    ->maxLength(2000),
+            ])
+            ->visible(fn ($record = null): bool => Auth::check() && ($record === null || method_exists($record, 'reportContent')))
+            ->disabled(fn ($record = null): bool => Auth::check() && $record !== null && $record->hasPendingReportBy(Auth::user()))
+            ->action(function ($record, array $data): void {
+                if (! Auth::check()) {
+                    Notification::make()
+                        ->title(__('filament-forum::filament-forum.reports.login-required'))
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
+                if ($record->hasPendingReportBy(Auth::user())) {
+                    Notification::make()
+                        ->title(__('filament-forum::filament-forum.reports.already-reported'))
+                        ->warning()
+                        ->send();
+
+                    return;
+                }
+
+                $record->reportContent(
+                    reporter: Auth::user(),
+                    reason: $data['reason'] ?? null,
+                    details: $data['details'] ?? null,
+                );
+
+                Notification::make()
+                    ->title(__('filament-forum::filament-forum.reports.submitted'))
+                    ->success()
+                    ->send();
+            });
+    }
+}

--- a/src/Filament/Resources/Admin/ForumContentReportResource.php
+++ b/src/Filament/Resources/Admin/ForumContentReportResource.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Tapp\FilamentForum\Filament\Resources\Admin;
+
+use BackedEnum;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\Textarea;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Auth;
+use Tapp\FilamentForum\Filament\Resources\Admin\ForumContentReportResource\Pages\ListForumContentReports;
+use Tapp\FilamentForum\Filament\Resources\Admin\ForumContentReportResource\Pages\ViewForumContentReport;
+use Tapp\FilamentForum\Models\ForumContentReport;
+
+class ForumContentReportResource extends Resource
+{
+    protected static ?string $model = ForumContentReport::class;
+
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-flag';
+
+    protected static ?int $navigationSort = 30;
+
+    public static function getNavigationLabel(): string
+    {
+        return __('filament-forum::filament-forum.reports.navigation-label');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('filament-forum::filament-forum.admin.navigation-group');
+    }
+
+    public static function isScopedToTenant(): bool
+    {
+        return config('filament-forum.tenancy.enabled', false);
+    }
+
+    public static function getTenantOwnershipRelationshipName(): string
+    {
+        if (! config('filament-forum.tenancy.enabled')) {
+            return 'tenant';
+        }
+
+        return ForumContentReport::getTenantRelationshipName();
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('filament-forum::filament-forum.reports.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('filament-forum::filament-forum.reports.plural-label');
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                TextColumn::make('reportable_type')
+                    ->label(__('filament-forum::filament-forum.reports.table.content-type'))
+                    ->formatStateUsing(fn (string $state): string => class_basename($state))
+                    ->sortable(),
+                TextColumn::make('reason')
+                    ->label(__('filament-forum::filament-forum.reports.reason'))
+                    ->formatStateUsing(fn (?string $state): string => config("filament-forum.reports.reasons.{$state}", $state ?? ''))
+                    ->sortable(),
+                TextColumn::make('status')
+                    ->label(__('filament-forum::filament-forum.reports.status'))
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => ForumContentReport::statuses()[$state] ?? $state)
+                    ->color(fn (string $state): string => match ($state) {
+                        ForumContentReport::STATUS_RESOLVED => 'success',
+                        ForumContentReport::STATUS_DISMISSED => 'gray',
+                        default => 'warning',
+                    })
+                    ->sortable(),
+                TextColumn::make('reporter.name')
+                    ->label(__('filament-forum::filament-forum.reports.table.reporter'))
+                    ->sortable(),
+                TextColumn::make('created_at')
+                    ->label(__('filament-forum::filament-forum.reports.table.reported-at'))
+                    ->since()
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->label(__('filament-forum::filament-forum.reports.status'))
+                    ->options(ForumContentReport::statuses()),
+            ])
+            ->recordActions([
+                ActionGroup::make([
+                    ViewAction::make(),
+                    static::resolveAction(),
+                    static::dismissAction(),
+                ])->tooltip(__('filament-forum::filament-forum.reports.actions')),
+            ], position: RecordActionsPosition::BeforeColumns);
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Grid::make([
+                    'default' => 1,
+                    'md' => 3,
+                ])
+                    ->columnSpanFull()
+                    ->schema([
+                        Section::make(__('filament-forum::filament-forum.reports.content'))
+                            ->columnSpan(2)
+                            ->schema([
+                                TextEntry::make('reportable_type')
+                                    ->label(__('filament-forum::filament-forum.reports.table.content-type'))
+                                    ->formatStateUsing(fn (string $state): string => class_basename($state)),
+                                TextEntry::make('details')
+                                    ->label(__('filament-forum::filament-forum.reports.details'))
+                                    ->placeholder(__('filament-forum::filament-forum.reports.no-details'))
+                                    ->columnSpanFull(),
+                                TextEntry::make('reportable.name')
+                                    ->label(__('filament-forum::filament-forum.forum-post.table.label.name'))
+                                    ->placeholder(__('filament-forum::filament-forum.forum-post.unknown')),
+                                TextEntry::make('reportable.content')
+                                    ->label(__('filament-forum::filament-forum.comments.edit-comment'))
+                                    ->html()
+                                    ->prose()
+                                    ->placeholder(__('filament-forum::filament-forum.forum-post.unknown'))
+                                    ->columnSpanFull(),
+                            ]),
+                        Section::make(__('filament-forum::filament-forum.reports.review'))
+                            ->columnSpan(1)
+                            ->schema([
+                                TextEntry::make('status')
+                                    ->label(__('filament-forum::filament-forum.reports.status'))
+                                    ->badge()
+                                    ->formatStateUsing(fn (string $state): string => ForumContentReport::statuses()[$state] ?? $state),
+                                TextEntry::make('reason')
+                                    ->label(__('filament-forum::filament-forum.reports.reason'))
+                                    ->formatStateUsing(fn (?string $state): string => config("filament-forum.reports.reasons.{$state}", $state ?? '')),
+                                TextEntry::make('reporter.name')
+                                    ->label(__('filament-forum::filament-forum.reports.table.reporter')),
+                                TextEntry::make('reviewer.name')
+                                    ->label(__('filament-forum::filament-forum.reports.reviewer'))
+                                    ->placeholder(__('filament-forum::filament-forum.reports.not-reviewed')),
+                                TextEntry::make('resolution_note')
+                                    ->label(__('filament-forum::filament-forum.reports.resolution-note'))
+                                    ->placeholder(__('filament-forum::filament-forum.reports.no-resolution-note')),
+                            ]),
+                    ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListForumContentReports::route('/'),
+            'view' => ViewForumContentReport::route('/{record}'),
+        ];
+    }
+
+    public static function resolveAction(): Action
+    {
+        return Action::make('resolve')
+            ->label(__('filament-forum::filament-forum.reports.resolve'))
+            ->icon('heroicon-o-check-circle')
+            ->color('success')
+            ->visible(fn (ForumContentReport $record): bool => $record->isPending())
+            ->schema([
+                Textarea::make('resolution_note')
+                    ->label(__('filament-forum::filament-forum.reports.resolution-note'))
+                    ->rows(3)
+                    ->maxLength(2000),
+            ])
+            ->action(function (ForumContentReport $record, array $data): void {
+                $record->resolve(Auth::user(), $data['resolution_note'] ?? null);
+            });
+    }
+
+    public static function dismissAction(): Action
+    {
+        return Action::make('dismiss')
+            ->label(__('filament-forum::filament-forum.reports.dismiss'))
+            ->icon('heroicon-o-x-circle')
+            ->color('gray')
+            ->visible(fn (ForumContentReport $record): bool => $record->isPending())
+            ->schema([
+                Textarea::make('resolution_note')
+                    ->label(__('filament-forum::filament-forum.reports.resolution-note'))
+                    ->rows(3)
+                    ->maxLength(2000),
+            ])
+            ->action(function (ForumContentReport $record, array $data): void {
+                $record->dismiss(Auth::user(), $data['resolution_note'] ?? null);
+            });
+    }
+}

--- a/src/Filament/Resources/Admin/ForumContentReportResource/Pages/ListForumContentReports.php
+++ b/src/Filament/Resources/Admin/ForumContentReportResource/Pages/ListForumContentReports.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tapp\FilamentForum\Filament\Resources\Admin\ForumContentReportResource\Pages;
+
+use Filament\Resources\Pages\ListRecords;
+use Tapp\FilamentForum\Filament\Resources\Admin\ForumContentReportResource;
+
+class ListForumContentReports extends ListRecords
+{
+    protected static string $resource = ForumContentReportResource::class;
+}

--- a/src/Filament/Resources/Admin/ForumContentReportResource/Pages/ViewForumContentReport.php
+++ b/src/Filament/Resources/Admin/ForumContentReportResource/Pages/ViewForumContentReport.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tapp\FilamentForum\Filament\Resources\Admin\ForumContentReportResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Resources\Pages\ViewRecord;
+use Tapp\FilamentForum\Filament\Resources\Admin\ForumContentReportResource;
+
+class ViewForumContentReport extends ViewRecord
+{
+    protected static string $resource = ForumContentReportResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            ForumContentReportResource::resolveAction(),
+            ForumContentReportResource::dismissAction(),
+        ];
+    }
+}

--- a/src/Filament/Resources/ForumPosts/Schemas/ForumPostInfolist.php
+++ b/src/Filament/Resources/ForumPosts/Schemas/ForumPostInfolist.php
@@ -8,6 +8,7 @@ use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Tapp\FilamentForum\Filament\Actions\ReportForumContentAction;
 use Tapp\FilamentForum\Filament\Infolists\Components\ForumCommentsEntry;
 use Tapp\FilamentForum\Filament\Infolists\Components\ForumPostReactionsEntry;
 use Tapp\FilamentForum\Models\ForumPost;
@@ -60,6 +61,7 @@ class ForumPostInfolist
                                     }'
                                 );
                             }),
+                        ReportForumContentAction::make(),
                     ])
                     ->schema([
                         Grid::make([

--- a/src/FilamentForumServiceProvider.php
+++ b/src/FilamentForumServiceProvider.php
@@ -36,6 +36,7 @@ class FilamentForumServiceProvider extends PackageServiceProvider
                 'create_favorite_forum_post_table',
                 'create_forum_subscriptions_table',
                 'create_forum_post_subscriptions_table',
+                'create_forum_content_reports_table',
                 'create_forum_post_views_table',
                 'create_forum_comments_table',
                 'create_forum_comment_reactions_table',

--- a/src/Livewire/ForumComments.php
+++ b/src/Livewire/ForumComments.php
@@ -17,6 +17,7 @@ use Livewire\Attributes\On;
 use Livewire\Component;
 use Tapp\FilamentForum\Events\ForumCommentCreated;
 use Tapp\FilamentForum\Events\UserWasMentioned;
+use Tapp\FilamentForum\Filament\Actions\ReportForumContentAction;
 use Tapp\FilamentForum\Models\ForumComment;
 use Tapp\FilamentForum\Models\ForumPost;
 
@@ -283,6 +284,43 @@ class ForumComments extends Component implements HasActions, HasSchemas
 
                 Notification::make()
                     ->title(__('filament-forum::filament-forum.comments.deleted'))
+                    ->success()
+                    ->send();
+            });
+    }
+
+    public function reportCommentAction(): Action
+    {
+        return ReportForumContentAction::make('reportComment')
+            ->action(function (array $arguments, array $data): void {
+                if (! Auth::check()) {
+                    Notification::make()
+                        ->title(__('filament-forum::filament-forum.reports.login-required'))
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
+                $comment = ForumComment::findOrFail($arguments['commentId']);
+
+                if ($comment->hasPendingReportBy(Auth::user())) {
+                    Notification::make()
+                        ->title(__('filament-forum::filament-forum.reports.already-reported'))
+                        ->warning()
+                        ->send();
+
+                    return;
+                }
+
+                $comment->reportContent(
+                    reporter: Auth::user(),
+                    reason: $data['reason'] ?? null,
+                    details: $data['details'] ?? null,
+                );
+
+                Notification::make()
+                    ->title(__('filament-forum::filament-forum.reports.submitted'))
                     ->success()
                     ->send();
             });

--- a/src/Models/ForumComment.php
+++ b/src/Models/ForumComment.php
@@ -16,6 +16,7 @@ use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Tapp\FilamentForum\Events\CommentWasReacted;
 use Tapp\FilamentForum\Models\Traits\BelongsToTenant;
+use Tapp\FilamentForum\Models\Traits\CanReportForumContent;
 
 /**
  * @property int $id
@@ -31,6 +32,7 @@ use Tapp\FilamentForum\Models\Traits\BelongsToTenant;
 class ForumComment extends Model implements HasMedia
 {
     use BelongsToTenant;
+    use CanReportForumContent;
     use HasFactory;
     use InteractsWithMedia;
 

--- a/src/Models/ForumContentReport.php
+++ b/src/Models/ForumContentReport.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tapp\FilamentForum\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Tapp\FilamentForum\Events\ForumContentReportDismissed;
+use Tapp\FilamentForum\Events\ForumContentReported;
+use Tapp\FilamentForum\Events\ForumContentReportResolved;
+use Tapp\FilamentForum\Models\Traits\BelongsToTenant;
+
+/**
+ * @property string $status
+ */
+class ForumContentReport extends Model
+{
+    use BelongsToTenant;
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_RESOLVED = 'resolved';
+
+    public const STATUS_DISMISSED = 'dismissed';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'reviewed_at' => 'datetime',
+    ];
+
+    public static function statuses(): array
+    {
+        return [
+            self::STATUS_PENDING => __('filament-forum::filament-forum.reports.status.pending'),
+            self::STATUS_RESOLVED => __('filament-forum::filament-forum.reports.status.resolved'),
+            self::STATUS_DISMISSED => __('filament-forum::filament-forum.reports.status.dismissed'),
+        ];
+    }
+
+    public function reportable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function reporter(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function reviewer(): BelongsTo
+    {
+        return $this->belongsTo(config('auth.providers.users.model'), 'reviewed_by_id');
+    }
+
+    public function scopePending(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_PENDING);
+    }
+
+    public function scopeResolved(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_RESOLVED);
+    }
+
+    public function scopeDismissed(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_DISMISSED);
+    }
+
+    public function isPending(): bool
+    {
+        return $this->status === self::STATUS_PENDING;
+    }
+
+    public function resolve($reviewer, ?string $note = null): void
+    {
+        $this->updateReviewState(self::STATUS_RESOLVED, $reviewer, $note);
+
+        ForumContentReportResolved::dispatch($this);
+    }
+
+    public function dismiss($reviewer, ?string $note = null): void
+    {
+        $this->updateReviewState(self::STATUS_DISMISSED, $reviewer, $note);
+
+        ForumContentReportDismissed::dispatch($this);
+    }
+
+    public function markReported(): void
+    {
+        ForumContentReported::dispatch($this);
+    }
+
+    protected function updateReviewState(string $status, $reviewer, ?string $note = null): void
+    {
+        $this->forceFill([
+            'status' => $status,
+            'reviewed_by_id' => $reviewer?->getKey(),
+            'reviewed_at' => now(),
+            'resolution_note' => $note,
+        ])->save();
+    }
+}

--- a/src/Models/ForumPost.php
+++ b/src/Models/ForumPost.php
@@ -13,12 +13,14 @@ use Tapp\FilamentForum\Events\ForumPostCreated;
 use Tapp\FilamentForum\Events\PostWasReacted;
 use Tapp\FilamentForum\Models\Traits\BelongsToTenant;
 use Tapp\FilamentForum\Models\Traits\CanFavoriteForumPost;
+use Tapp\FilamentForum\Models\Traits\CanReportForumContent;
 use Tapp\FilamentForum\Models\Traits\CanSubscribeToForumPost;
 
 class ForumPost extends Model
 {
     use BelongsToTenant;
     use CanFavoriteForumPost;
+    use CanReportForumContent;
     use CanSubscribeToForumPost;
 
     /** @use HasFactory<ForumPostFactory> */

--- a/src/Models/Traits/CanReportForumContent.php
+++ b/src/Models/Traits/CanReportForumContent.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tapp\FilamentForum\Models\Traits;
+
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Tapp\FilamentForum\Models\ForumContentReport;
+
+trait CanReportForumContent
+{
+    public function contentReports(): MorphMany
+    {
+        return $this->morphMany(ForumContentReport::class, 'reportable');
+    }
+
+    public function pendingContentReports(): MorphMany
+    {
+        return $this->contentReports()->where('status', ForumContentReport::STATUS_PENDING);
+    }
+
+    public function reportContent($reporter, ?string $reason = null, ?string $details = null): ForumContentReport
+    {
+        $values = [
+            'reason' => $reason,
+            'details' => $details,
+        ];
+
+        if (config('filament-forum.tenancy.enabled')) {
+            $tenantColumnName = static::getTenantColumnName();
+            $tenantId = $this->{$tenantColumnName};
+
+            if ($tenantId) {
+                $values[$tenantColumnName] = $tenantId;
+            }
+        }
+
+        /** @var ForumContentReport $report */
+        $report = $this->contentReports()->updateOrCreate(
+            [
+                'reporter_id' => $reporter->getKey(),
+                'reporter_type' => get_class($reporter),
+                'status' => ForumContentReport::STATUS_PENDING,
+            ],
+            $values
+        );
+
+        $report->markReported();
+
+        return $report;
+    }
+
+    public function hasPendingReportBy($reporter): bool
+    {
+        return $this->pendingContentReports()
+            ->where('reporter_id', $reporter->getKey())
+            ->where('reporter_type', get_class($reporter))
+            ->exists();
+    }
+
+    public function getPendingReportsCountAttribute(): int
+    {
+        return $this->pendingContentReports()->count();
+    }
+}

--- a/src/Models/Traits/HasForumContentReports.php
+++ b/src/Models/Traits/HasForumContentReports.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tapp\FilamentForum\Models\Traits;
+
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Tapp\FilamentForum\Models\ForumContentReport;
+
+trait HasForumContentReports
+{
+    public function forumContentReports(): MorphMany
+    {
+        return $this->morphMany(ForumContentReport::class, 'reporter');
+    }
+}

--- a/tests/Feature/ForumContentReportTest.php
+++ b/tests/Feature/ForumContentReportTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Event;
+use Tapp\FilamentForum\Events\ForumContentReportDismissed;
+use Tapp\FilamentForum\Events\ForumContentReported;
+use Tapp\FilamentForum\Events\ForumContentReportResolved;
+use Tapp\FilamentForum\Models\Forum;
+use Tapp\FilamentForum\Models\ForumContentReport;
+use Tapp\FilamentForum\Models\ForumPost;
+
+beforeEach(function () {
+    $this->userModel = config('filament-forum.user.model');
+    $this->tenantModel = config('filament-forum.tenancy.model');
+});
+
+it('can report a forum post with tenancy enabled', function () {
+    Event::fake();
+
+    $tenantModel = $this->tenantModel;
+    $userModel = $this->userModel;
+
+    $team = $tenantModel::factory()->create();
+    $author = $userModel::factory()->create();
+    $reporter = $userModel::factory()->create();
+
+    actingAs($reporter);
+    Filament::setTenant($team);
+
+    $tenantColumn = Forum::getTenantColumnName();
+    $forum = Forum::factory()->create([$tenantColumn => $team->id]);
+    $post = ForumPost::factory()->create([
+        'forum_id' => $forum->id,
+        'user_id' => $author->id,
+        $tenantColumn => $team->id,
+    ]);
+
+    $report = $post->reportContent($reporter, 'spam', 'This is promotional.');
+
+    expect($report)->toBeInstanceOf(ForumContentReport::class);
+    expect($report->reportable->is($post))->toBeTrue();
+    expect($report->reporter->is($reporter))->toBeTrue();
+    expect($report->reason)->toBe('spam');
+    expect($report->{$tenantColumn})->toBe($team->id);
+    expect($post->hasPendingReportBy($reporter))->toBeTrue();
+    expect($post->pending_reports_count)->toBe(1);
+    expect($reporter->forumContentReports()->count())->toBe(1);
+
+    Event::assertDispatched(ForumContentReported::class, fn (ForumContentReported $event): bool => $event->report->is($report));
+});
+
+it('updates an existing pending report by the same reporter', function () {
+    $tenantModel = $this->tenantModel;
+    $userModel = $this->userModel;
+
+    $team = $tenantModel::factory()->create();
+    $author = $userModel::factory()->create();
+    $reporter = $userModel::factory()->create();
+
+    actingAs($reporter);
+    Filament::setTenant($team);
+
+    $tenantColumn = Forum::getTenantColumnName();
+    $forum = Forum::factory()->create([$tenantColumn => $team->id]);
+    $post = ForumPost::factory()->create([
+        'forum_id' => $forum->id,
+        'user_id' => $author->id,
+        $tenantColumn => $team->id,
+    ]);
+
+    $firstReport = $post->reportContent($reporter, 'spam', 'First details.');
+    $secondReport = $post->reportContent($reporter, 'harassment', 'Updated details.');
+
+    expect($secondReport->id)->toBe($firstReport->id);
+    expect($post->contentReports()->count())->toBe(1);
+    expect($secondReport->fresh()->reason)->toBe('harassment');
+    expect($secondReport->fresh()->details)->toBe('Updated details.');
+});
+
+it('can resolve and dismiss reports', function () {
+    Event::fake();
+
+    $tenantModel = $this->tenantModel;
+    $userModel = $this->userModel;
+
+    $team = $tenantModel::factory()->create();
+    $author = $userModel::factory()->create();
+    $reporter = $userModel::factory()->create();
+    $reviewer = $userModel::factory()->create();
+
+    actingAs($reviewer);
+    Filament::setTenant($team);
+
+    $tenantColumn = Forum::getTenantColumnName();
+    $forum = Forum::factory()->create([$tenantColumn => $team->id]);
+    $post = ForumPost::factory()->create([
+        'forum_id' => $forum->id,
+        'user_id' => $author->id,
+        $tenantColumn => $team->id,
+    ]);
+
+    $resolvedReport = $post->reportContent($reporter, 'spam');
+    $resolvedReport->resolve($reviewer, 'Removed content.');
+
+    expect($resolvedReport->fresh()->status)->toBe(ForumContentReport::STATUS_RESOLVED);
+    expect($resolvedReport->fresh()->reviewer->is($reviewer))->toBeTrue();
+    expect($resolvedReport->fresh()->reviewed_at)->not->toBeNull();
+    expect($resolvedReport->fresh()->resolution_note)->toBe('Removed content.');
+
+    Event::assertDispatched(ForumContentReportResolved::class, fn (ForumContentReportResolved $event): bool => $event->report->is($resolvedReport));
+
+    $dismissedReport = $post->reportContent($reporter, 'other');
+    $dismissedReport->dismiss($reviewer, 'No issue found.');
+
+    expect($dismissedReport->fresh()->status)->toBe(ForumContentReport::STATUS_DISMISSED);
+    expect(ForumContentReport::pending()->count())->toBe(0);
+    expect(ForumContentReport::resolved()->count())->toBe(1);
+    expect(ForumContentReport::dismissed()->count())->toBe(1);
+
+    Event::assertDispatched(ForumContentReportDismissed::class, fn (ForumContentReportDismissed $event): bool => $event->report->is($dismissedReport));
+});

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -5,6 +5,7 @@ namespace Tapp\FilamentForum\Tests\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Tapp\FilamentForum\Models\Traits\HasFavoriteForumPost;
+use Tapp\FilamentForum\Models\Traits\HasForumContentReports;
 use Tapp\FilamentForum\Models\Traits\HasForumSubscriptions;
 use Tapp\FilamentForum\Tests\Database\Factories\UserFactory;
 
@@ -12,6 +13,7 @@ class User extends Authenticatable
 {
     use HasFactory;
     use HasFavoriteForumPost;
+    use HasForumContentReports;
     use HasForumSubscriptions;
 
     protected $guarded = [];


### PR DESCRIPTION
## Summary
- add reusable forum content reports for posts and comments
- add report actions, moderation status events, and an admin review resource
- include tenant-aware report storage plus reporter/user helper traits

## Verification
- composer test
- composer analyse
- composer format