### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,13 +18,15 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=8.3",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
         "filament/filament": "^5.0|^4.0",
         "spatie/laravel-package-tools": "^1.0",
         "spatie/laravel-medialibrary": "^11.0"
@@ -26,10 +26,10 @@
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "larastan/larastan": "^2.9||^3.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
-        "pestphp/pest": "^2.0||^3.0",
-        "pestphp/pest-plugin-arch": "^2.5||^3.0",
-        "pestphp/pest-plugin-laravel": "^2.0||^3.0",
+        "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0||^8.22.0",
+        "pestphp/pest": "^2.0||^3.0||^4.0",
+        "pestphp/pest-plugin-arch": "^2.5||^3.0||^4.0",
+        "pestphp/pest-plugin-laravel": "^2.0||^3.0||^4.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
         "phpstan/phpstan-phpunit": "^1.3||^2.0",


### PR DESCRIPTION
## Summary
- allow `illuminate/contracts` 13.x in addition to existing Laravel 10-12 support
- allow Testbench 11 and Pest 4 for Laravel 13 verification
- add Laravel 13 / Testbench 11 to the GitHub Actions test matrix

## Verification
- `composer validate --strict`
- `composer update --with='illuminate/contracts:13.*' --with='orchestra/testbench:11.*' --no-interaction --prefer-dist --no-progress`
- `composer test` with Laravel 13.15.0, Filament 5.6.7, Testbench 11.1.0, Pest 4.7.3
- `composer analyse`
