### PR TITLE
Use Node 24-compatible GitHub Actions

### DIFF
--- a/.github/workflows/larastan.yml
+++ b/.github/workflows/larastan.yml
@@ -21,7 +21,7 @@ jobs:
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@v4
         with:
             dependency-versions: "highest"
             composer-options: "--no-scripts"

--- a/.github/workflows/larastan.yml
+++ b/.github/workflows/larastan.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - '**.php'
+      - '.github/workflows/larastan.yml'
       - 'phpstan.neon.dist'
 
 jobs:


### PR DESCRIPTION
## Summary
- bump GitHub Actions workflow dependencies to Node 24-compatible majors
- update checkout/composer/cache/artifact actions where present

## Verification
- CI will verify this workflow-only change on the PR
