### PR TITLE
Support Pest 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
         "spatie/laravel-medialibrary": "^11.0"
     },
     "require-dev": {
+        "larastan/larastan": "^2.9||^3.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "larastan/larastan": "^2.9||^3.0",
         "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0||^8.22.0",
-        "pestphp/pest": "^2.0||^3.0||^4.0",
-        "pestphp/pest-plugin-arch": "^2.5||^3.0||^4.0",
-        "pestphp/pest-plugin-laravel": "^2.0||^3.0||^4.0",
+        "pestphp/pest": "^2.0||^3.0||^4.0|^5.0",
+        "pestphp/pest-plugin-arch": "^2.5||^3.0||^4.0|^5.0",
+        "pestphp/pest-plugin-laravel": "^2.0||^3.0||^4.0|^5.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
         "phpstan/phpstan-phpunit": "^1.3||^2.0",


### PR DESCRIPTION
## Summary
- Allow Pest 5 in composer dev constraints.
- Include matching Pest plugin constraints where this package uses Pest plugins.
- Keep existing Pest version support in place for current stable installs.

## Verification
- `composer validate --no-check-publish`
- `composer update --dry-run`

Note: Pest 5 is currently available to Composer as a dev line, so this prepares the package constraints while preserving current stable Pest 4 resolution.
