### PR TITLE
Fix Update Changelog workflow push failure

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.release.target_commitish }}
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@v1
@@ -23,6 +23,6 @@ jobs:
       - name: Commit updated CHANGELOG
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          branch: ${{ github.event.release.target_commitish }}
+          branch: ${{ github.event.repository.default_branch }}
           commit_message: Update CHANGELOG
           file_pattern: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to `Filament Forum` will be documented in this file.
 
 Add reusable forum content reports and moderation review workflow.
 
+## v2.4.1 - 2026-07-04
+
+### What's Changed
+
+- Allow Pest 5 in Composer dev constraints.
+- Preserve current stable Pest support for existing installs.
+- Include matching Pest plugin constraints where applicable.
+
+### Verification
+
+- PR checks passed, or local Composer validation/dry-run was used where the repository has no GitHub checks.
+
 ## v2.1.3 - 2026-04-09
 
 Flatten post view: collapsible comment form, no card nesting


### PR DESCRIPTION
## Summary
- The `Update Changelog` workflow (triggered on `release: released`) failed because it pushed to `github.event.release.target_commitish`, which can be a raw commit SHA rather than a branch name. `git-auto-commit-action` then tried to push to a branch named after that SHA and git rejected it with "not a full refname."
- Changed both the checkout `ref` and the commit action's `branch` to use `github.event.repository.default_branch` instead, so the changelog update always targets a real branch.
- Added the missing `v2.4.1` changelog entry that failed to commit during the broken run.

See the failing run: https://github.com/TappNetwork/Filament-Forum/actions/runs/28719111134/job/85165569236

## Test plan
- [ ] Cut a new release and confirm the `Update Changelog` workflow succeeds and pushes the CHANGELOG.md update to `main`